### PR TITLE
PersistRepository service

### DIFF
--- a/app/services/fetch_and_process_repositories.rb
+++ b/app/services/fetch_and_process_repositories.rb
@@ -8,12 +8,12 @@ class FetchAndProcessRepositories < ApplicationService
 
   private
 
-  def process_repositories(repository_names)
-    repository_names.each { |repository_name| schedule_job(repository_name) }
+  def process_repositories(repository_data_array)
+    repository_data_array.each { |repository_data| schedule_job(repository_data) }
     Success(nil)
   end
 
-  def schedule_job(repository_name)
-    CallServiceObjectJob.perform_later(ProcessRepository, repository_name)
+  def schedule_job(repository_data)
+    CallServiceObjectJob.perform_later(ProcessRepository, repository_data)
   end
 end

--- a/app/services/fetch_repositories.rb
+++ b/app/services/fetch_repositories.rb
@@ -2,7 +2,10 @@
 
 class FetchRepositories < ApplicationService
   def call
-    Success(Octokit.org_repos("netguru").map(&:full_name))
+    Success(
+      Octokit.org_repos("netguru")
+        .map { |repo| { name: repo.full_name, url: repo.html_url } }
+    )
   rescue Octokit::NotFound => e
     Failure(e)
   end

--- a/app/services/persist_repository.rb
+++ b/app/services/persist_repository.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PersistRepository < ApplicationService
-  def call(_repository_name)
-    raise NotImplementedError
+  def call(repository_data)
+    Success(Repository.find_or_create_by!(repository_data))
   end
 end

--- a/app/services/process_repository.rb
+++ b/app/services/process_repository.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ProcessRepository < ApplicationService
-  def call(repository_name)
-    Success(repository_name)
+  def call(repository_data)
+    Success(repository_data)
       .bind(:persist_repository)
       .bind(:fetch_gemfile_from_repo)
       .bind(:parse_gemfile)
@@ -14,8 +14,8 @@ class ProcessRepository < ApplicationService
 
   attr_reader :repository
 
-  def persist_repository(repository_name)
-    PersistRepository.call(repository_name)
+  def persist_repository(repository_data)
+    PersistRepository.call(repository_data)
   end
 
   def fetch_gemfile_from_repo(repository)


### PR DESCRIPTION
Changed `string:repository_name` to `hash:repository_data`.
Created `PersistRepository` service.